### PR TITLE
Add Logitech Dual Action support.

### DIFF
--- a/tellopy/examples/joystick_and_video.py
+++ b/tellopy/examples/joystick_and_video.py
@@ -143,6 +143,11 @@ class JoystickF310:
     RIGHT_Y_REVERSE = -1.0
     DEADZONE = 0.08
 
+# Hold down the Logitech button in the center of the controller while plugging
+# in the USB cord. In order for the controller to use this mapping, the switch
+# on the back must be in the "D" position and the Mode light must be off. It is
+# off by default, so once the controller is connected, switch it on, then off.
+# Note that the D-pad transmits JOYHATMOTION events in this mode.
 class JoystickDualAction:
     # d-pad
     UP = -1  # UP
@@ -161,6 +166,10 @@ class JoystickDualAction:
     BACKWARD = 1  # A
     RIGHT = 2  # B
     FORWARD = 3  # Y
+    # UNUSED = 8 #BACK
+    # UNUSED = 9 #START
+    # UNUSED = 10 #L_JOY
+    # UNUSED = 11 #R_JOY
 
     # axis
     LEFT_X = 0

--- a/tellopy/examples/joystick_and_video.py
+++ b/tellopy/examples/joystick_and_video.py
@@ -143,6 +143,36 @@ class JoystickF310:
     RIGHT_Y_REVERSE = -1.0
     DEADZONE = 0.08
 
+class JoystickDualAction:
+    # d-pad
+    UP = -1  # UP
+    DOWN = -1  # DOWN
+    ROTATE_LEFT = -1  # LEFT
+    ROTATE_RIGHT = -1  # RIGHT
+
+    # bumper triggers
+    LAND = 4  # L1
+    TAKEOFF = 5  # R1
+    # UNUSED = 6 #L2
+    # UNUSED = 7 #R2
+
+    # buttons
+    LEFT = 0  # X
+    BACKWARD = 1  # A
+    RIGHT = 2  # B
+    FORWARD = 3  # Y
+
+    # axis
+    LEFT_X = 0
+    LEFT_Y = 1
+    RIGHT_X = 2
+    RIGHT_Y = 3
+    LEFT_X_REVERSE = 1.0
+    LEFT_Y_REVERSE = -1.0
+    RIGHT_X_REVERSE = 1.0
+    RIGHT_Y_REVERSE = -1.0
+    DEADZONE = 0.08
+
 class JoystickXONE:
     # d-pad
     UP = 0  # UP
@@ -453,6 +483,8 @@ def main():
             buttons = JoystickPS3
         elif js_name in ('Logitech Gamepad F310'):
             buttons = JoystickF310
+        elif js_name == 'Logitech Dual Action':
+            buttons = JoystickDualAction
         elif js_name == 'Xbox One Wired Controller':
             buttons = JoystickXONE
         elif js_name == 'Microsoft X-Box One S pad':


### PR DESCRIPTION
While branded as the Logitech F310, [this controller](https://www.bestbuy.com/site/logitech-f310-gaming-pad-blue-black/1260591.p?skuId=1260591) connects as "Logitech Dual Action" and the mapping is different from the provided Logitech F310 mapping.

The comments in `joystick_and_video.py` describe the (somewhat convoluted) process of connecting the controller and ensuring that its joysticks and D-pad transmit the proper events.