### PR TITLE
Wait for connack before doing anything else.

### DIFF
--- a/tellopy/_internal/tello.py
+++ b/tellopy/_internal/tello.py
@@ -136,6 +136,7 @@ class Tello(object):
     def connect(self):
         """Connect is used to send the initial connection request to the drone."""
         self.__publish(event=self.__EVENT_CONN_REQ)
+        self.wait_for_connection(10.0)
 
     def wait_for_connection(self, timeout=None):
         """Wait_for_connection will block until the connection is established."""


### PR DESCRIPTION
Many [issues](https://github.com/hanyazou/TelloPy/issues?q=is%3Aissue+is%3Aopen+timeout) have been raised regarding video timeouts when using [keyboard_and_video.py](https://github.com/hanyazou/TelloPy/blob/develop-0.7.0/tellopy/examples/keyboard_and_video.py)

I believe the issue comes from [not calling `wait_for_connection` between `connect` and `start_video`](https://github.com/hanyazou/TelloPy/blob/2e3ff77f87448307d6d2656c91ac80e2fb352193/tellopy/examples/keyboard_and_video.py#L231)

I never have issues with [video_effect.py](https://github.com/hanyazou/TelloPy/blob/2e3ff77f87448307d6d2656c91ac80e2fb352193/tellopy/examples/video_effect.py#L15) and `wait_for_connection` is the only explanation I could find. I haven't been having issues with `keyboard_and_video` ever since.

I find forcing the users to call `wait_for_connection` themselves to be very bug-prone (as we can see from this example), so I have opted to move it directly in `connect`. This should take care of these issues forever.